### PR TITLE
Fix missing `landing` directory preventing `update.check` file creation

### DIFF
--- a/Scripts/GLOBAL-hyde
+++ b/Scripts/GLOBAL-hyde
@@ -393,6 +393,7 @@ eval "$(declare -F | sed -e 's/-f /-fx /')"
 export cacheDir="${HOME}/.cache/hyde"
 export meta_file="${cacheDir}/hyde.meta" #! This is almost immovable! use chattr to dissable perms
 export settingDir="${cacheDir}/hyde-settings"
+export landingDir="${cacheDir}/landing"
 
 #! Temporary
 [ -e "${cacheDir}/hyde-cli/hyde.meta" ] && mv "${HOME}/.cache/hyde-cli/hyde.meta" "${meta_file}"
@@ -434,6 +435,7 @@ make_dir=(
     "${BkpDir}"
     "${cacheDir}"
     "${settingDir}"
+    "${landingDir}"
     "${etcDir}"
     "${HYDE_RUNTIME_DIR}"
 )


### PR DESCRIPTION
Without this fix on fresh install update check was triggered every time I used Hyde cli. 

Also when run, error was shown:
```
touch: cannot touch '<home>/.cache/hyde/landing/update.check': No such file or directory
```

This patch adds missing `landing` directory