### PR TITLE
Feature: Use `get reset --hard` instead of `git pull` for updating repo

### DIFF
--- a/Hyde
+++ b/Hyde
@@ -263,7 +263,9 @@ update() { #? Pull updates from Hyde repository
 	get_aurhlpr
 	print_prompt -y "Pulling Hyde repo..."
 	git stash >/dev/null
-	git pull
+	git fetch
+	remote_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+	git reset ${remote_branch} --hard
 	git stash pop 2>/dev/null
 	print_prompt -y "Checking Hyde CLI updates..."
 	[[ ${CLI_PATH} != *"/usr"* ]] && export HYDE_LOCAL=1


### PR DESCRIPTION
This feature is useful, when user is on non-main HyDE branch, and this branch was force-pushed in remote repo (for example, rebased on main branch).

In current scheme with `git pull` attempt to update on force-pushed branch will fail, but if use `get reset`, branch will be updated successfully.

In other cases it behaves exact as `git pull`.